### PR TITLE
feat: Bayesian Neural Network - Implementation & Example

### DIFF
--- a/examples/bayesian_neural_network.py
+++ b/examples/bayesian_neural_network.py
@@ -1,0 +1,281 @@
+"""
+Bayesian Neural Network
+=======================
+
+This example implements the training and prediction of a
+Bayesian Neural Network.
+Predictions from a Haiku MLP fro the same data are shown
+as a reference.
+
+References
+----------
+
+[1] Blundell C., Cornebise J., Kavukcuoglu K., Wierstra D.
+    "Weight Uncertainty in Neural Networks".
+    ICML, 2015.
+"""
+
+from jax.config import config
+config.update("jax_enable_x64", True)
+
+import haiku as hk
+import jax
+from jax import numpy as jnp, random
+from distrax import Normal
+from ramsey.data import sample_from_gaussian_process
+from ramsey.contrib.models import BayesianLinear, BayesianNeuralNetwork
+from ramsey.contrib.train import train_model
+import matplotlib.pyplot as plt
+
+rng = hk.PRNGSequence(12356)
+
+def data(key, rho, sigma, n=1000):
+
+    (x_target, y_target), f_target = sample_from_gaussian_process(
+        key, batch_size=1, num_observations=n, rho=rho, sigma=sigma
+    )
+
+    return (x_target.reshape(n,1), y_target.reshape(n,1)), f_target.reshape(n,1)
+
+def _bayesian_nn(**kwargs):
+
+    def _inv_softplus(x):
+        return jnp.log(jnp.exp(x)-1)
+
+    w_prior = Normal(loc=0, scale=1.05)
+    b_prior = Normal(loc=0, scale=1.05)
+
+    w_rho_init = hk.initializers.TruncatedNormal(
+        mean=_inv_softplus(6.71e-3),
+        stddev=0.1)
+
+    b_rho_init = hk.initializers.TruncatedNormal(
+        mean=_inv_softplus(6.71e-3),
+        stddev=0.1)
+
+    bayes_1 = BayesianLinear(8, w_prior=w_prior, b_prior=b_prior,
+                                w_rho_init=w_rho_init, b_rho_init=b_rho_init,
+                                activation=jax.nn.leaky_relu)
+
+    bayes_2 = BayesianLinear(8, w_prior=w_prior, b_prior=b_prior,
+                                w_rho_init=w_rho_init, b_rho_init=b_rho_init,
+                                activation=jax.nn.leaky_relu)
+
+    bayes_3 = BayesianLinear(1, w_prior=w_prior, b_prior=b_prior,
+                                w_rho_init=w_rho_init, b_rho_init=b_rho_init,
+                                activation=None)
+
+    layers = [bayes_1, bayes_2, bayes_3]
+
+    lklh_log_sigma_init = hk.initializers.RandomUniform(jnp.log(0.1), jnp.log(1.0))
+
+    bayesian_nn = BayesianNeuralNetwork(layers, lklh_log_sigma_init)
+
+    return bayesian_nn(**kwargs)
+
+def _std_nn(x, **kwargs):
+
+    standard_nn = hk.nets.MLP([8,8,1], with_bias=True)
+    return standard_nn(x, **kwargs)
+
+def _plot_loss(bayesian_nn_loss, std_nn_loss):
+
+    _, axes = plt.subplots(ncols=2, nrows=1, figsize=(18, 6))
+
+    losses = [bayesian_nn_loss, std_nn_loss]
+    labels = ['neg. ELBO','MSE']
+    titles = ['Bayesian NN', 'Standard NN']
+
+    [(ax.plot(
+            jnp.arange(len(losses[_])),
+            jnp.squeeze(losses[_]),
+            # color="black",
+            alpha=0.5,
+            label=labels[_]
+        ),
+    ax.set_title(titles[_]),
+    ax.set_xlabel('iteration'),
+    ax.grid(),
+    ax.legend()) for (_,ax) in enumerate(axes)]
+
+def _plot_bayesian_nn_samples(rng, ax, nn, nn_params, x, n_samples = 10):
+
+    y_s = [nn.apply(params=nn_params,rng=next(rng),x=x) for _ in range(n_samples)]
+
+    srt_idxs = jnp.argsort(jnp.squeeze(x))
+
+    [ax.plot(
+        jnp.squeeze(x)[srt_idxs], jnp.squeeze(y)[srt_idxs], color="blue", alpha = 0.1
+    ) for y in y_s]
+
+def _plot_bayesian_nn_mean_std(rng, ax, nn, nn_params, x, n_samples = 100):
+
+    y_s = [nn.apply(params=nn_params,rng=next(rng),x=x) for _ in range(n_samples)]
+
+    y_s = jnp.squeeze(jnp.stack([y for y in y_s]))
+
+    mean = jnp.mean(y_s, axis=0)
+    sigma = jnp.std(y_s, axis=0)
+
+    srt_idxs = jnp.argsort(jnp.squeeze(x))
+
+    ax.plot(    jnp.squeeze(x)[srt_idxs], jnp.squeeze(mean)[srt_idxs],
+                color="blue", alpha = 0.5,
+                label='Posterior Mean')
+
+    ax.fill_between(jnp.squeeze(x)[srt_idxs],
+                 jnp.squeeze(mean+1.644854*sigma)[srt_idxs],
+                 jnp.squeeze(mean-1.644854*sigma)[srt_idxs],
+                 color="blue", alpha=0.05, label=r'90% Posterior Interval')
+
+
+def _plot_standard_nn(rng, ax, standard_nn, standard_nn_params, x):
+
+    y_s = standard_nn.apply(params=standard_nn_params,rng=next(rng),x=x)
+
+    srt_idxs = jnp.argsort(jnp.squeeze(x))
+
+    ax.plot(    jnp.squeeze(x)[srt_idxs], jnp.squeeze(y_s)[srt_idxs],
+                color="green", alpha = 0.5,
+                label='Predictions Standard NN')
+
+
+def plot(   rng,
+            bayesian_nn, bayesian_nn_params, bayesian_nn_loss,
+            standard_nn, standard_nn_params, standard_nn_loss,
+            x, f, x_train, y_train):
+
+    _plot_loss(bayesian_nn_loss, standard_nn_loss)
+
+    _, ax = plt.subplots(figsize=(8, 3))
+    srt_idxs = jnp.argsort(jnp.squeeze(x))
+    ax.plot(
+        jnp.squeeze(x)[srt_idxs],
+        jnp.squeeze(f)[srt_idxs],
+        color="black",
+        alpha=0.5,
+        label="Latent function " + r"$f \sim GP$"
+    )
+    ax.scatter(
+        jnp.squeeze(x_train),
+        jnp.squeeze(y_train),
+        color="red",
+        marker="+",
+        alpha=0.2,
+        label="Training data"
+    )
+
+    _plot_bayesian_nn_mean_std(rng, ax, bayesian_nn, bayesian_nn_params, x)
+    _plot_bayesian_nn_samples(rng, ax, bayesian_nn, bayesian_nn_params, x)
+    _plot_standard_nn(rng, ax, standard_nn, standard_nn_params, x)
+
+    ax.legend(
+        loc="best",
+        frameon=False,
+    )
+    ax.grid()
+
+    ax.set_frame_on(False)
+    plt.show()
+
+def bayesian_nn_objective(par, key, model, x, y):
+    """
+    The BNN training objective is the approx. ELBO (see [1]).
+    The number m controls how many samples are used for this
+    approximation.
+    """
+
+    m = 5
+
+    keys = random.split(key, m)
+
+    obj_list = []
+
+    for _ in range(m):
+        obj = model.apply(
+            params=par,
+            rng=keys[_],
+            x=x,
+            y=y
+        )
+
+        obj_list.append(obj)
+
+    obj = jnp.mean(jnp.asarray(obj_list))
+
+    return obj
+
+def std_nn_objective(par, key, model, x, y):
+
+    y_star = model.apply(
+        params=par,
+        rng=key,
+        x=x
+    )
+
+    obj = jnp.mean(jnp.square(y_star - y))
+    return obj
+
+def choose_training_samples(key, x, y, n_train):
+
+    train_idxs = random.choice(
+        key, jnp.arange(x.shape[0]), shape=(n_train,1), replace=False
+    )
+    x_train, y_train = jnp.take(x,train_idxs), jnp.take(y, train_idxs)
+    return x_train, y_train
+
+def run():
+
+    n_train = 100
+    n_iter = 5000
+    stepsize = 0.01
+
+    (x, y), f = data(next(rng), 0.7, 1.0)
+    x_train, y_train = choose_training_samples(next(rng), x, y, n_train)
+
+    key = next(rng)
+
+    print('\nTrain Bayesian Neural Network')
+    bayesian_nn = hk.transform(_bayesian_nn)
+    bayesian_nn_params = bayesian_nn.init(key, x=x_train, y=y_train)
+    bayesian_nn_params, bayesian_nn_loss = train_model(
+        bayesian_nn,
+        bayesian_nn_objective,
+        bayesian_nn_params,
+        key,
+        x=x_train,
+        y=y_train,
+        n_iter=n_iter,
+        stepsize=stepsize
+    )
+
+    print('\nTrain Standard Neural Network')
+    std_nn = hk.transform(_std_nn)
+    std_nn_params = std_nn.init(key, x=x_train)
+    std_nn_params, std_nn_loss = train_model(
+        std_nn,
+        std_nn_objective,
+        std_nn_params,
+        key,
+        x=x_train,
+        y=y_train,
+        n_iter=n_iter,
+        stepsize=stepsize
+    )
+
+    plot(
+        rng,
+        bayesian_nn,
+        bayesian_nn_params,
+        bayesian_nn_loss,
+        std_nn,
+        std_nn_params,
+        std_nn_loss,
+        x,
+        f,
+        x_train,
+        y_train
+    )
+
+if __name__ == "__main__":
+    run()

--- a/examples/bayesian_neural_network.py
+++ b/examples/bayesian_neural_network.py
@@ -39,38 +39,11 @@ def data(key, rho, sigma, n=1000):
 
 def _bayesian_nn(**kwargs):
 
-    def _inv_softplus(x):
-        return jnp.log(jnp.exp(x)-1)
-
-    w_prior = Normal(loc=0, scale=1.05)
-    b_prior = Normal(loc=0, scale=1.05)
-
-    w_rho_init = hk.initializers.TruncatedNormal(
-        mean=_inv_softplus(6.71e-3),
-        stddev=0.1)
-
-    b_rho_init = hk.initializers.TruncatedNormal(
-        mean=_inv_softplus(6.71e-3),
-        stddev=0.1)
-
-    bayes_1 = BayesianLinear(8, w_prior=w_prior, b_prior=b_prior,
-                                w_rho_init=w_rho_init, b_rho_init=b_rho_init,
-                                activation=jax.nn.leaky_relu)
-
-    bayes_2 = BayesianLinear(8, w_prior=w_prior, b_prior=b_prior,
-                                w_rho_init=w_rho_init, b_rho_init=b_rho_init,
-                                activation=jax.nn.leaky_relu)
-
-    bayes_3 = BayesianLinear(1, w_prior=w_prior, b_prior=b_prior,
-                                w_rho_init=w_rho_init, b_rho_init=b_rho_init,
-                                activation=None)
-
+    bayes_1 = BayesianLinear(8)
+    bayes_2 = BayesianLinear(8)
+    bayes_3 = BayesianLinear(1,activation=None)
     layers = [bayes_1, bayes_2, bayes_3]
-
-    lklh_log_sigma_init = hk.initializers.RandomUniform(jnp.log(0.1), jnp.log(1.0))
-
-    bayesian_nn = BayesianNeuralNetwork(layers, lklh_log_sigma_init)
-
+    bayesian_nn = BayesianNeuralNetwork(layers)
     return bayesian_nn(**kwargs)
 
 def _std_nn(x, **kwargs):

--- a/ramsey/_src/contrib/bayesian_neural_network/BayesianLayer.py
+++ b/ramsey/_src/contrib/bayesian_neural_network/BayesianLayer.py
@@ -1,0 +1,17 @@
+import abc
+
+from jax import numpy as jnp
+from jax import random
+
+
+# pylint: disable=too-few-public-methods
+class BayesianLayer(metaclass=abc.ABCMeta):
+    """
+    Abstract BayesianLayer class
+    """
+
+    @abc.abstractmethod
+    def __call__(
+        self, x: jnp.ndarray, key: random.PRNGKey, is_training: bool = False
+    ):
+        pass

--- a/ramsey/_src/contrib/bayesian_neural_network/BayesianLinear.py
+++ b/ramsey/_src/contrib/bayesian_neural_network/BayesianLinear.py
@@ -1,0 +1,223 @@
+from typing import Callable, Optional
+
+import haiku as hk
+import jax
+from distrax import Distribution, MultivariateNormalDiag, Normal
+from jax import numpy as jnp
+from jax import random
+
+from ramsey._src.contrib.bayesian_neural_network.BayesianLayer import (
+    BayesianLayer,
+)
+
+
+# pylint: disable=too-many-instance-attributes,too-many-locals
+class BayesianLinear(hk.Module, BayesianLayer):
+    """
+    Bayesian Linear Layer
+
+    Bayesian Linear Layer using distributions over weights and bias.
+
+    The KL divergences between the variational posteriors and priors
+    for weigths and bias are calculated.
+    The KL divergence terms can be used to obtain the ELBO as an objective
+    to train a Bayesian Neural Network.
+
+    See [1] for details.
+
+    References
+    ----------
+
+    [1] Blundell C., Cornebise J., Kavukcuoglu K., Wierstra D.
+        "Weight Uncertainty in Neural Networks".
+        ICML, 2015.
+    """
+
+    def __init__(
+        self,
+        output_size: int,
+        w_mu_init: Optional[hk.initializers.Initializer] = None,
+        w_rho_init: Optional[hk.initializers.Initializer] = None,
+        b_mu_init: Optional[hk.initializers.Initializer] = None,
+        b_rho_init: Optional[hk.initializers.Initializer] = None,
+        with_bias: bool = True,
+        activation: Callable[[jnp.ndarray], jnp.ndarray] = jax.nn.relu,
+        w_prior: Optional[Distribution] = Normal(loc=0, scale=1),
+        b_prior: Optional[Distribution] = Normal(loc=0, scale=1),
+        name: Optional[str] = None,
+    ):
+        """
+        Instantiates a Bayesian Linear Layer
+
+        Parameters
+        ----------
+        output_size: int
+            number of layer outputs
+        w_mu_init: Optional[hk.initializers.Initializer]
+            init for mean of var. posterior for weigths
+        w_rho_init: Optional[hk.initializers.Initializer]
+            init for sigma = log(1+exp(rho)) of var. posterior for weigths
+        b_mu_init: Optional[hk.initializers.Initializer]
+            init for mean of var. posterior for bias
+        b_rho_init: Optional[hk.initializers.Initializer]
+            init for sigma = log(1+exp(rho)) of var. posterior for bias
+        with_bias: bool
+            control usage of bias term
+        activation: Callable[[jnp.ndarray], jnp.ndarray]
+            choose the activation function (use None for no activation)
+        w_prior: Optional[Distribution]
+            prior distriburtion for weights
+        b_prior: Optional[Distribution]
+            prior distribution for bias
+        name: Optional[str]
+            name of the layer
+        """
+
+        super().__init__(name=name)
+        self._output_size = output_size
+        self._with_bias = with_bias
+        self._w_mu_init = w_mu_init
+        self._w_rho_init = w_rho_init
+        self._b_mu_init = b_mu_init or jnp.zeros
+        self._b_rho_init = b_rho_init
+        self._activation = activation
+        self._w_prior = w_prior
+        self._b_prior = b_prior
+
+    def __call__(
+        self, x: jnp.ndarray, key: random.PRNGKey, is_training: bool = False
+    ):
+        """
+        Instantiates a sparse Gaussian process
+
+        Parameters
+        ----------
+        x: jnp.ndarray
+            layer inputs
+        key : random.PRNGKey,
+            number of inducing points
+        is_training : bool
+            training mode where KL divergence terms are calculated and returned
+        """
+
+        x = jnp.atleast_2d(x)
+        dtype = x.dtype
+
+        n_in = x.shape[-1]
+        n_out = self._output_size
+
+        w_mu, w_sigma = self._get_w_var_dist_params((n_in, n_out), dtype)
+        W = self._reparameterize(w_mu, w_sigma, key)
+        output = jnp.matmul(x, W)
+
+        if self._with_bias:
+            b_mu, b_sigma = self._get_b_var_dist_params(n_out, dtype)
+            b = self._reparameterize(b_mu, b_sigma, key)
+            b_ = jnp.broadcast_to(b, output.shape)
+            output = output + b_
+
+        output = self._activate(output)
+
+        if is_training:
+            kl_div = self._kl_div_w(w_mu, w_sigma, W)
+            if self._with_bias:
+                kl_div += self._kl_div_b(b_mu, b_sigma, b)
+            return output, kl_div
+
+        return output
+
+    def _kl_div_b(self, mu, sigma, b):
+
+        # variational posterior: q(b|theta)
+        var_posterior = Normal(loc=mu, scale=sigma)
+
+        # KL from posterior to prior p(b)
+        kl_div = -jnp.sum(self._b_prior.log_prob(b))
+        kl_div += jnp.sum(var_posterior.log_prob(b))
+
+        return kl_div
+
+    def _kl_div_w(self, mu, sigma, w):
+
+        # variational posterior: q(w|theta)
+        var_posterior = Normal(loc=mu, scale=sigma)
+
+        # KL from posterior to prior p(w)
+        kl_div = -jnp.sum(self._w_prior.log_prob(w))
+        kl_div += jnp.sum(var_posterior.log_prob(w))
+
+        return kl_div
+
+    def _activate(self, x):
+
+        output = x
+        if self._activation is not None:
+            output = self._activation(x)
+        return output
+
+    def _reparameterize(self, mu, sigma, key):
+
+        e = MultivariateNormalDiag(loc=jnp.zeros(mu.shape)).sample(seed=key)
+        z = mu + sigma * e
+        return z
+
+    def _get_b_var_dist_params(self, n_out, dtype):
+
+        b_mu_var = self._get_mu_b([n_out], dtype)
+        b_sigma_var = self._get_sigma_b([n_out], dtype)
+
+        return b_mu_var, b_sigma_var
+
+    def _get_w_var_dist_params(self, layer_dim, dtype):
+
+        w_mu_var = self._get_mu_w(layer_dim, dtype)
+        w_sigma_var = self._get_sigma_w(layer_dim, dtype)
+
+        return w_mu_var, w_sigma_var
+
+    def _get_mu_w(self, shape, dtype):
+
+        n_in, _ = shape
+        mu_init = self._w_mu_init
+
+        if mu_init is None:
+            stddev = 1.0 / jnp.sqrt(n_in)
+            mu_init = hk.initializers.TruncatedNormal(stddev=stddev)
+
+        mu = hk.get_parameter("w_mu", shape=shape, dtype=dtype, init=mu_init)
+
+        return mu
+
+    def _get_sigma_w(self, shape, dtype):
+
+        rho_init = self._w_rho_init
+
+        if rho_init is None:
+            rho_init = hk.initializers.TruncatedNormal(mean=-5, stddev=0.1)
+
+        rho = hk.get_parameter("w_rho", shape=shape, dtype=dtype, init=rho_init)
+        sigma = self._softplus(rho)
+
+        return sigma
+
+    def _get_mu_b(self, shape, dtype):
+
+        mu = hk.get_parameter(
+            "b_mu", shape=shape, dtype=dtype, init=self._b_mu_init
+        )
+        return mu
+
+    def _get_sigma_b(self, shape, dtype):
+
+        rho_init = self._b_rho_init
+
+        if rho_init is None:
+            rho_init = hk.initializers.TruncatedNormal(mean=-5, stddev=0.1)
+
+        rho = hk.get_parameter("b_rho", shape=shape, dtype=dtype, init=rho_init)
+        sigma = self._softplus(rho)
+
+        return sigma
+
+    def _softplus(self, x):
+        return jnp.log(1 + jnp.exp(x))

--- a/ramsey/_src/contrib/bayesian_neural_network/BayesianLinear.py
+++ b/ramsey/_src/contrib/bayesian_neural_network/BayesianLinear.py
@@ -193,7 +193,9 @@ class BayesianLinear(hk.Module, BayesianLayer):
         rho_init = self._w_rho_init
 
         if rho_init is None:
-            rho_init = hk.initializers.TruncatedNormal(mean=-5, stddev=0.1)
+            rho_init = hk.initializers.RandomUniform(
+                self._inv_softplus(1e-2), self._inv_softplus(1e-1)
+            )
 
         rho = hk.get_parameter("w_rho", shape=shape, dtype=dtype, init=rho_init)
         sigma = self._softplus(rho)
@@ -212,7 +214,9 @@ class BayesianLinear(hk.Module, BayesianLayer):
         rho_init = self._b_rho_init
 
         if rho_init is None:
-            rho_init = hk.initializers.TruncatedNormal(mean=-5, stddev=0.1)
+            rho_init = hk.initializers.RandomUniform(
+                self._inv_softplus(1e-2), self._inv_softplus(1e-1)
+            )
 
         rho = hk.get_parameter("b_rho", shape=shape, dtype=dtype, init=rho_init)
         sigma = self._softplus(rho)
@@ -221,3 +225,6 @@ class BayesianLinear(hk.Module, BayesianLayer):
 
     def _softplus(self, x):
         return jnp.log(1 + jnp.exp(x))
+
+    def _inv_softplus(self, x):
+        return jnp.log(jnp.exp(x) - 1)

--- a/ramsey/_src/contrib/bayesian_neural_network/BayesianNeuralNetwork.py
+++ b/ramsey/_src/contrib/bayesian_neural_network/BayesianNeuralNetwork.py
@@ -1,0 +1,110 @@
+from typing import Iterable, Optional
+
+import haiku as hk
+from distrax import Normal
+from jax import numpy as jnp
+
+from ramsey._src.contrib.bayesian_neural_network.BayesianLayer import (
+    BayesianLayer,
+)
+from ramsey._src.contrib.bayesian_neural_network.BayesianLinear import (
+    BayesianLinear,
+)
+
+
+class BayesianNeuralNetwork(hk.Module):
+    """
+    Bayesian Neural Network
+
+    Implements a BNN. The BNN layers can a mix of Bayesian (BayesianLayer) and
+    normal (e.g. hk.Linear) layers.
+
+    Training objective is the ELBO and is calculated according [1].
+
+    References
+    ----------
+
+    [1] Blundell C., Cornebise J., Kavukcuoglu K., Wierstra D.
+        "Weight Uncertainty in Neural Networks".
+        ICML, 2015.
+    """
+
+    def __init__(
+        self,
+        layers: Iterable[hk.Module],
+        lklh_log_sigma_init: Optional[hk.initializers.Initializer] = None,
+        name: Optional[str] = None,
+    ):
+        """
+        Instantiates a Bayesian Neural Network
+
+        Parameters
+        ----------
+        layers: Iterable[hk.Module]
+            layers of the BNN
+        lklh_log_sigma_init: Optional[hk.initializers.Initializer]
+            an initializer object from Haiku or None
+        name: Optional[str]
+            name of the layer
+        """
+
+        super().__init__(name=name)
+        self._layers = layers
+        self._lklh_log_sigma_init = lklh_log_sigma_init
+
+    def __call__(self, x: jnp.ndarray, **kwargs):
+
+        if "y" in kwargs:
+            y = kwargs["y"]
+            return self._negative_elbo(x, y)
+
+        return self._forward(x)
+
+    def _forward(self, x):
+
+        key = hk.next_rng_key()
+
+        for layer in self._layers:
+            if isinstance(layer, BayesianLayer):
+                x = layer(x, key)
+            else:
+                x = layer(x)
+        return x
+
+    def _negative_elbo(self, x, y):
+
+        dtype = x.dtype
+        key = hk.next_rng_key()
+        kl_div = 0
+
+        for layer in self._layers:
+            if isinstance(layer, BayesianLinear):
+                x, kl_contribution = layer(x, key, is_training=True)
+                kl_div += kl_contribution
+            else:
+                x = layer(x)
+
+        mu = x
+        sigma = self._get_sigma(dtype) * jnp.ones((mu.shape[0], 1))
+        p_likelihood = Normal(loc=mu, scale=sigma)
+        likelihood = jnp.sum(p_likelihood.log_prob(y))
+
+        elbo = likelihood - kl_div
+
+        return -elbo
+
+    def _get_sigma(self, dtype):
+
+        log_sigma_init = self._lklh_log_sigma_init
+
+        if log_sigma_init is None:
+            log_sigma_init = hk.initializers.RandomUniform(
+                jnp.log(0.1), jnp.log(1.0)
+            )
+
+        log_sigma = hk.get_parameter(
+            "lklh_log_sigma", [], dtype=dtype, init=log_sigma_init
+        )
+        sigma = jnp.exp(log_sigma)
+
+        return sigma

--- a/ramsey/_src/contrib/bayesian_neural_network/BayesianNeuralNetwork.py
+++ b/ramsey/_src/contrib/bayesian_neural_network/BayesianNeuralNetwork.py
@@ -78,7 +78,7 @@ class BayesianNeuralNetwork(hk.Module):
         kl_div = 0
 
         for layer in self._layers:
-            if isinstance(layer, BayesianLinear):
+            if isinstance(layer, BayesianLayer):
                 x, kl_contribution = layer(x, key, is_training=True)
                 kl_div += kl_contribution
             else:

--- a/ramsey/_src/contrib/train_model.py
+++ b/ramsey/_src/contrib/train_model.py
@@ -1,0 +1,44 @@
+from typing import Callable
+
+import haiku as hk
+import jax
+import optax
+from haiku._src.data_structures import FlatMapping
+from jax import numpy as jnp
+from jax import random
+
+
+# pylint: disable=too-many-locals
+def train_model(
+    model: hk.Transformed,  # pylint: disable=invalid-name
+    objective: Callable,
+    params: FlatMapping,
+    rng: random.PRNGKey,
+    x: jnp.ndarray,  # pylint: disable=invalid-name
+    y: jnp.ndarray,  # pylint: disable=invalid-name
+    n_iter=1000,
+    stepsize=1e-3,
+):
+    @jax.jit
+    def step(params, opt_state, rng, x, y):
+        obj, grads = jax.value_and_grad(objective)(params, rng, model, x, y)
+        updates, opt_state = optimizer.update(grads, opt_state)
+        params = optax.apply_updates(params, updates)
+        return params, opt_state, obj
+
+    rng_seq = hk.PRNGSequence(rng)
+    optimizer = optax.adam(stepsize)
+    opt_state = optimizer.init(params)
+    objectives = [0.0] * n_iter
+
+    for _ in range(n_iter):
+
+        params, opt_state, loss = step(params, opt_state, next(rng_seq), x, y)
+
+        objectives[_] = loss
+        if _ % 200 == 0 or _ == n_iter - 1:
+            print(f"step {_}: obj={loss:.5f}")
+
+    objectives = jnp.asarray(objectives)
+
+    return params, objectives

--- a/ramsey/contrib/models.py
+++ b/ramsey/contrib/models.py
@@ -1,5 +1,11 @@
+from ramsey._src.contrib.bayesian_neural_network.BayesianLinear import (
+    BayesianLinear,
+)
+from ramsey._src.contrib.bayesian_neural_network.BayesianNeuralNetwork import (
+    BayesianNeuralNetwork,
+)
 from ramsey._src.contrib.timeseries.recurrent_attentive_neural_process import (
     RANP,
 )
 
-__all__ = ["RANP"]
+__all__ = ["RANP", "BayesianLinear", "BayesianNeuralNetwork"]

--- a/ramsey/contrib/train.py
+++ b/ramsey/contrib/train.py
@@ -1,0 +1,3 @@
+from ramsey._src.contrib.train_model import train_model
+
+__all__ = ["train_model"]

--- a/ramsey/data.py
+++ b/ramsey/data.py
@@ -47,6 +47,34 @@ def load_m4_time_series_data(
 
 
 # pylint: disable=too-many-locals,invalid-name
+def sample_from_polynomial_function(
+    rng, batch_size=10, order=1, num_observations=100, sigma=0.1
+):
+    x = jnp.linspace(-jnp.pi, jnp.pi, num_observations).reshape(
+        (num_observations, 1)
+    )
+    ys = []
+    fs = []
+    for _ in range(batch_size):
+
+        coeffs = list(random.uniform(next(rng), shape=(order + 1, 1)) - 1)
+        f = 0
+        for i in range(order + 1):
+            f += coeffs[i] * x**i
+
+        y = f + random.normal(next(rng), shape=(num_observations, 1)) * sigma
+
+        fs.append(f.reshape((1, num_observations, 1)))
+        ys.append(y.reshape((1, num_observations, 1)))
+
+    x = jnp.tile(x, [batch_size, 1, 1])
+    y = jnp.vstack(jnp.array(ys))
+    f = jnp.vstack(jnp.array(fs))
+
+    return (x, y), f
+
+
+# pylint: disable=too-many-locals,invalid-name
 def sample_from_sine_function(key, batch_size=10, num_observations=100):
     x = jnp.linspace(-jnp.pi, jnp.pi, num_observations).reshape(
         (num_observations, 1)


### PR DESCRIPTION
Hello @dirmeier ,

I finished the BNN implementation. The implementation has the API that you sketched in your e-mail.

As discussed I added it into the `contrib` folders.

The provided example fits a BNN to data sampled from a GP. As a reference also a standard Haiku MLP is fitted.

The predictions of both network types are visualized together with the latent function and training data. For BNN also the 90% posterior intervals are plotted. 
The example also plots the objectives = f(iter) which is the negative ELBO for BNN and MSE for the standard MLP.

The figures below show examples of such plots:

![image](https://user-images.githubusercontent.com/101034965/203797174-6e2a6d61-20ee-4ccc-b8a1-03f461b1d5bf.png)


![image](https://user-images.githubusercontent.com/101034965/203797235-8a74dda9-a1a4-48cd-97ca-f6ced7c91122.png)


Regards Marco